### PR TITLE
fix drop autoload of extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ cd LangSim
 conda env create -f environment.yml --name LangSim
 ```
 
-### As Docker Container 
-Work in Progress 
+### Via Docker Container
+We build a docker container on every commit to the `main` branch.
+You can pull the container from the [Docker Hub](https://hub.docker.com/r/ltalirz/langsim) using:
+```bash
+docker run -p 8866:8866 ltalirz/langsim
+```
 
 ## Using the package
 The package currently provides two interfaces, one for python / jupyter users to query the large language model directly

--- a/llm_compmat/magics.py
+++ b/llm_compmat/magics.py
@@ -16,10 +16,8 @@ parse_argstring)
 from IPython.display import Markdown
 from .llm import get_executor
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-
 def get_output(messages):
-    agent_executor = get_executor(OPENAI_API_KEY=OPENAI_API_KEY)
+    agent_executor = get_executor(OPENAI_API_KEY=os.getenv("OPENAI_API_KEY"))
     return list(agent_executor.stream({"conversation": messages}))[-1]
 
 # Class to manage state and expose the main magics
@@ -29,7 +27,6 @@ class CompMatMagics(Magics):
     def __init__(self, shell):
         # You must call the parent constructor
         super(CompMatMagics, self).__init__(shell)
-        #self.api_key = openai.api_key = os.getenv("OPENAI_API_KEY")
         self.api_key = os.getenv("OPENAI_API_KEY")
         self.last_code = ""
         self.messages = []

--- a/postBuild
+++ b/postBuild
@@ -5,7 +5,8 @@ pip install .
 rm -rf build llm_compmat.egg-info
 
 # Autoload line magic
-mkdir -p ~/.ipython/profile_default/startup
-cat > ~/.ipython/profile_default/startup/load_extensions.py <<EOF
-get_ipython().run_line_magic('load_ext', 'llm_compmat')
-EOF
+# Unfortunately seems to cause mybinder startup to time out
+#mkdir -p ~/.ipython/profile_default/startup
+#cat > ~/.ipython/profile_default/startup/load_extensions.py <<EOF
+#get_ipython().run_line_magic('load_ext', 'llm_compmat')
+#EOF


### PR DESCRIPTION
For some reason, loading the ipython magic at jupyterlab startup seems to time out (maybe gets to slow for mybinder timeout).