### PR TITLE
ReAct agent implementation

### DIFF
--- a/langsim/llm.py
+++ b/langsim/llm.py
@@ -1,6 +1,8 @@
 from langchain.agents import AgentExecutor
 from langchain.agents.output_parsers.openai_tools import OpenAIToolsAgentOutputParser
+from langchain.agents.output_parsers import JSONAgentOutputParser
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.tools.render import render_text_description_and_args
 from langchain.agents.format_scratchpad.openai_tools import (
     format_to_openai_tool_messages,
 )
@@ -13,24 +15,19 @@ from langsim.tools.interface import (
     get_atom_dict_bulk_structure,
     get_atom_dict_equilibrated_structure,
 )
-from langsim.prompt import SYSTEM_PROMPT
+from langsim.prompt import SYSTEM_PROMPT_ALT, SYSTEM_PROMPT
+from langchain import hub
 
 
-def get_executor(api_provider, api_key, api_url=None, api_model=None, api_temperature=0):
+def get_executor(api_provider, api_key, api_url=None, api_model=None, api_temperature=0, agent_type="default"):
     if api_provider.lower() == "openai":
         from langchain_openai import ChatOpenAI
         if api_model is None:
-            api_model = "gpt-4"
+            api_model = "gpt-4o"
         llm = ChatOpenAI(
             model=api_model, temperature=api_temperature, openai_api_key=api_key, base_url=api_url,
         )
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                ("system", SYSTEM_PROMPT),
-                ("human", "{conversation}"),
-                MessagesPlaceholder(variable_name="agent_scratchpad"),
-            ]
-        )
+
     elif api_provider.lower() == "anthropic":
         from langchain_anthropic import ChatAnthropic
         if api_model is None:
@@ -38,15 +35,17 @@ def get_executor(api_provider, api_key, api_url=None, api_model=None, api_temper
         llm = ChatAnthropic(
             model=api_model, temperature=api_temperature, anthropic_api_key=api_key,
         )
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                ("system", SYSTEM_PROMPT),
-                ("human", "{conversation}"),
-                MessagesPlaceholder(variable_name="agent_scratchpad"),
-            ]
+
+    elif api_provider.lower() == "groq":
+        from langchain_groq import ChatGroq
+        if api_model is None:
+            api_model = "Llama-3-Groq-70B-Tool-Use"
+        llm = ChatGroq(
+            model=api_model, temperature=api_temperature, groq_api_key=api_key,
         )
     else:
         raise ValueError()
+    
     tools = [
         get_equilibrium_volume,
         get_atom_dict_bulk_structure,
@@ -55,10 +54,34 @@ def get_executor(api_provider, api_key, api_url=None, api_model=None, api_temper
         get_bulk_modulus,
         get_experimental_elastic_property_wikipedia,
     ]
+
     llm_with_tools = llm.bind_tools(tools)
+
+    if agent_type == "react":
+        REACT_PROMPT_FROM_HUB = hub.pull("langchain-ai/react-agent-template")
+        prompt = REACT_PROMPT_FROM_HUB.partial(instructions=SYSTEM_PROMPT_ALT,
+                                               tools=render_text_description_and_args(tools),
+                                               tool_names=", ".join([t.name for t in tools]),
+                                               )
+        input_key = "input"
+        
+    elif agent_type == "default":
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", SYSTEM_PROMPT),
+                ("human", "{conversation}"),
+                MessagesPlaceholder(variable_name="agent_scratchpad"),
+            ]
+        )
+        input_key = "conversation"
+
+    else:
+        raise ValueError()
+    
+
     agent = (
         {
-            "conversation": lambda x: x["conversation"],
+            input_key: lambda x: x[input_key],
             "agent_scratchpad": lambda x: format_to_openai_tool_messages(
                 x["intermediate_steps"]
             ),
@@ -66,5 +89,6 @@ def get_executor(api_provider, api_key, api_url=None, api_model=None, api_temper
         | prompt
         | llm_with_tools
         | OpenAIToolsAgentOutputParser()
+        # | JSONAgentOutputParser()
     )
     return AgentExecutor(agent=agent, tools=tools, verbose=True)

--- a/langsim/prompt.py
+++ b/langsim/prompt.py
@@ -12,3 +12,12 @@ Rules:
 - Do not start a calculation unless the human has chosen a model. 
 - Do not convert the AtomDict class to a python dictionary.
 """
+
+SYSTEM_PROMPT_ALT = """Your name is LangSim and you are very powerful agent in the field of commputational materials science.
+
+Rules:
+- Do not start a calculation unless the human has chosen a model.
+- Ask to the human which model want to use before running a calculation
+- Do not convert the AtomDict class to a python dictionary.
+"""
+

--- a/langsim/tools/interface.py
+++ b/langsim/tools/interface.py
@@ -32,7 +32,11 @@ def get_atom_dict_equilibrated_structure(atom_dict: AtomsDict, calculator_str: s
 
     Args:
         atom_dict (AtomsDict): DataClass representing the atomic structure
-        calculator_str (str): selected model specified by the calculator string
+        calculator_str (str): a model from the following options: "emt", "mace"
+                              - "emt": Effective medium theory is a computationally efficient, analytical model
+                                 that describes the macroscopic properties of composite materials. 
+                              - "mace": this is a machine learning force field for predicting many-body atomic
+                                 interactions that covers the periodic table.     
 
     Returns:
         AtomsDict: DataClass representing the equilibrated atomic structure
@@ -55,7 +59,11 @@ def plot_equation_of_state(atom_dict: AtomsDict, calculator_str: str) -> str:
 
     Args:
         atom_dict (AtomsDict): DataClass representing the atomic structure
-        calculator_str (str): selected model specified by the calculator string
+        calculator_str (str): a model from the following options: "emt", "mace"
+                              - "emt": Effective medium theory is a computationally efficient, analytical model
+                                 that describes the macroscopic properties of composite materials. 
+                              - "mace": this is a machine learning force field for predicting many-body atomic
+                                 interactions that covers the periodic table.     
 
     Returns:
         str: plot of the equation of state
@@ -74,7 +82,11 @@ def get_bulk_modulus(atom_dict: AtomsDict, calculator_str: str) -> str:
 
     Args:
         atom_dict (AtomsDict): DataClass representing the atomic structure
-        calculator_str (str): selected model specified by the calculator string
+        calculator_str (str): a model from the following options: "emt", "mace"
+                              - "emt": Effective medium theory is a computationally efficient, analytical model
+                                 that describes the macroscopic properties of composite materials. 
+                              - "mace": this is a machine learning force field for predicting many-body atomic
+                                 interactions that covers the periodic table.     
 
     Returns:
         str: Bulk Modulus in GPa
@@ -97,7 +109,11 @@ def get_equilibrium_volume(atom_dict: AtomsDict, calculator_str: str) -> str:
 
     Args:
         atom_dict (AtomsDict): DataClass representing the atomic structure
-        calculator_str (str): selected model specified by the calculator string
+        calculator_str (str): a model from the following options: "emt", "mace"
+                              - "emt": Effective medium theory is a computationally efficient, analytical model
+                                 that describes the macroscopic properties of composite materials. 
+                              - "mace": this is a machine learning force field for predicting many-body atomic
+                                 interactions that covers the periodic table.     
 
     Returns:
         str: Equilibrium volume in Angstrom^3


### PR DESCRIPTION
Here is an attempt of implementing a ReAct agent.
The main change is in using a specific prompt that implement 
the ReAct mechanism. There are different available, I took one 
from langchain hub labelled "langchain-ai/react-agent-template".

To enable this react agent, it's type has to be given in input to the get_executor.
The original agent is kept as default.
I also changed the ipython magic %%chat so that the agent type can be specified.

I did some testing with different models. I'll add some notebook later.