### PR TITLE
Only import calculator when it is selected

### DIFF
--- a/langsim/tools/helper.py
+++ b/langsim/tools/helper.py
@@ -1,11 +1,11 @@
-from ase.calculators.emt import EMT
-from mace.calculators import mace_mp
 
 
 def get_calculator(calculator_str: str = "emt"):
     if calculator_str == "emt":
+        from ase.calculators.emt import EMT
         return EMT()
     elif calculator_str == "mace":
+        from mace.calculators import mace_mp
         return mace_mp(
             model="medium", dispersion=False, default_dtype="float32", device="cpu"
         )


### PR DESCRIPTION
This should also allow running the workflow on Windows when the mace package is not available.